### PR TITLE
release: 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 1.5.0+idea2021
+published to:
+- [JetBrains marketplace](https://plugins.jetbrains.com/plugin/15673-asyncapi/versions/stable/167090)
+- [GitHub](https://github.com/Pakisan/jasyncapi-idea-plugin/releases/tag/1.4.0%2Bidea2021)
+
+### Added
+- Compatability with IDEA 2022.1
+
+### Changed
+- was changed `org.jetbrains.intellij` version
+  - 1.4.0 -> 1.5.3
+- was changed `intellij-plugin-verifier` version
+  - 1.268 -> 1.278
+- was changed `Gradle` version
+  - 6.8 -> 7.4.2
+- was changed `JUnit` version
+  - 4.12 -> 5.8.2
+
+
 ## 1.4.0+idea2021
 published to:
 - [JetBrains marketplace](https://plugins.jetbrains.com/plugin/15673-asyncapi/versions/stable/167090)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,8 +13,10 @@ repositories {
 
 dependencies {
     implementation(kotlin("stdlib"))
-    testImplementation("junit", "junit", "4.12")
     testImplementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.2")
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.8.2")
 }
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
@@ -59,5 +61,8 @@ tasks {
     }
     compileTestKotlin {
         kotlinOptions.jvmTarget = "11"
+    }
+    test {
+        useJUnitPlatform()
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,7 +50,7 @@ tasks.getByName<org.jetbrains.intellij.tasks.RunPluginVerifierTask>("runPluginVe
         "2021.3.2",
         "2021.3.3"
     ))
-    verifierVersion.set("1.268")
+    verifierVersion.set("1.278")
 }
 
 tasks {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.jetbrains.intellij") version "1.4.0"
+    id("org.jetbrains.intellij") version "1.5.3"
     java
     kotlin("jvm") version "1.6.20"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group "com.asyncapi.plugin.idea"
-version = "1.4.0+idea2021"
+version = "1.5.0+idea2021"
 
 repositories {
     mavenCentral()
@@ -21,18 +21,16 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version.set("2021.3")
+    version.set("2022.1")
     plugins.set(listOf("yaml"))
 }
 tasks.getByName<org.jetbrains.intellij.tasks.PatchPluginXmlTask>("patchPluginXml") {
     sinceBuild.set("211")
-    untilBuild.set("213.*")
+    untilBuild.set("221.*")
     changeNotes.set("""
-        <b>New AsyncAPI versions:</b>
+        <b>IDEA compatability:</b>
         <ul>
-            <li>2.1.0</li>
-            <li>2.2.0</li>
-            <li>2.3.0</li>
+            <li>IDEA 2022.1</li>
         </ul>
     """.trimIndent())
 }
@@ -50,7 +48,8 @@ tasks.getByName<org.jetbrains.intellij.tasks.RunPluginVerifierTask>("runPluginVe
         "2021.3",
         "2021.3.1",
         "2021.3.2",
-        "2021.3.3"
+        "2021.3.3",
+        "2022.1"
     ))
     verifierVersion.set("1.278")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("org.jetbrains.intellij") version "1.4.0"
     java
-    kotlin("jvm") version "1.4.21"
+    kotlin("jvm") version "1.6.20"
 }
 
 group "com.asyncapi.plugin.idea"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Added
- Compatability with IDEA 2022.1

### Changed
- was changed `org.jetbrains.intellij` version
  - 1.4.0 -> 1.5.3
- was changed `intellij-plugin-verifier` version
  - 1.268 -> 1.278
- was changed `Gradle` version
  - 6.8 -> 7.4.2
- was changed `JUnit` version
  - 4.12 -> 5.8.2