### PR TITLE
Support IntelliJ 2022.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,23 @@ Idea plugin for the [java-asyncapi](https://github.com/Pakisan/java-asyncapi) - 
 - File references resolving with auto-completion in AsyncAPI schema (json).
 
 ## Usage
-1. clone repository
+1. Clone repository
 ```sh
 git clone https://github.com/Pakisan/jasyncapi-idea-plugin.git
 ```
-2. move to jasyncapi-idea-plugin
+2. Move to jasyncapi-idea-plugin
 ```sh
 cd jasyncapi-idea-plugin
 ```
-3. build plugin
+3. IMPORTANT: Make sure you are using Java 17 or later!
+
+* Plugins for IntelliJ IDEA 2022.3 and later require building using Java 17 or later.
+* Consider using <a href="sdkman.io">SDKMAN</a> or a package manager to install a Java SDK that meets that minimum requirement. 
+
+
+4. Build plugin
 ```sh
-➜  jasyncapi-idea-plugin git:(feature/idea-plugin) ✗ ./gradlew buildPlugin
+./gradlew buildPlugin
 ...
 BUILD SUCCESSFUL in 24s
 11 actionable tasks: 11 executed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ tasks.getByName<org.jetbrains.intellij.tasks.PatchPluginXmlTask>("patchPluginXml
     sinceBuild.set("211")
     untilBuild.set("223.*")
     changeNotes.set("""
-        <p>Fix preview on Windows</p>
+        <p>Update to support IntelliJ 2022.3 / 223.*</p>
     """.trimIndent())
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,11 @@
 plugins {
-    id("org.jetbrains.intellij") version "1.9.0"
+    id("org.jetbrains.intellij") version "1.10.0"
     java
     kotlin("jvm") version "1.6.20"
 }
 
 group "com.asyncapi.plugin.idea"
-version = "1.7.1+idea2021"
+version = "1.8.0+idea2022"
 
 repositories {
     mavenCentral()
@@ -21,12 +21,12 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version.set("2022.2.3")
+    version.set("2022.3")
     plugins.set(listOf("yaml"))
 }
 tasks.getByName<org.jetbrains.intellij.tasks.PatchPluginXmlTask>("patchPluginXml") {
     sinceBuild.set("211")
-    untilBuild.set("222.*")
+    untilBuild.set("223.*")
     changeNotes.set("""
         <p>Fix preview on Windows</p>
     """.trimIndent())
@@ -54,17 +54,18 @@ tasks.getByName<org.jetbrains.intellij.tasks.RunPluginVerifierTask>("runPluginVe
         "2022.2",
         "2022.2.1",
         "2022.2.2",
-        "2022.2.3"
+        "2022.2.3",
+        "2022.3"
     ))
     verifierVersion.set("1.284")
 }
 
 tasks {
     compileKotlin {
-        kotlinOptions.jvmTarget = "11"
+        kotlinOptions.jvmTarget = "17"
     }
     compileTestKotlin {
-        kotlinOptions.jvmTarget = "11"
+        kotlinOptions.jvmTarget = "17"
     }
     test {
         useJUnitPlatform()


### PR DESCRIPTION
I'm starting to realize: we're going to need to do this whenever they announce a new EAP, correct?

2022.3 requires Java 17, so I build this with Java Temurin 17.0.5 (Eclipse's Java) -- installed with SDKMAN -- and then loaded it into my IntelliJ 2022.3. It seemed to work fine.